### PR TITLE
Fix apex/log url library readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The following libraries are being tested:
 
 - [Zerolog](https://github.com/rs/zerolog)
 - [Zap](https://github.com/uber-go/zap)
-- [Apex/log](https://github.com/uber-go/zap)
+- [Apex/log](https://github.com/apex/log)
 - [Logrus](https://github.com/sirupsen/logrus)
 - [Slog](https://pkg.go.dev/log/slog)
 - [SlogZap](https://github.com/uber-go/zap/tree/master/exp/zapslog) (Slog with


### PR DESCRIPTION
# Description

The Gihub URL of `apex/log` library is redirecting to the `uber-go` library. This PR redirects to https://github.com/apex/log, that I think that is the correct destination.