### PR TITLE
update phuslog to v1.0.98

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/apex/log v1.9.0
 	github.com/inconshreveable/log15 v2.16.0+incompatible
-	github.com/phuslu/log v1.0.88
+	github.com/phuslu/log v1.0.98
 	github.com/rs/zerolog v1.30.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/zerodha/logf v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/phuslu/log v1.0.88 h1:kivXMpYQ2hd9BxiJNhRM5xnaEZaGunQYlnRQdk/aBw8=
-github.com/phuslu/log v1.0.88/go.mod h1:F8osGJADo5qLK/0F88djWwdyoZZ9xDJQL1HYRHFEkS0=
+github.com/phuslu/log v1.0.98 h1:u+GTxbrzJsxZFMGzUUNthD8Dqj2t3xJsCEZwWWtbB58=
+github.com/phuslu/log v1.0.98/go.mod h1:F8osGJADo5qLK/0F88djWwdyoZZ9xDJQL1HYRHFEkS0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/phuslog_test.go
+++ b/phuslog_test.go
@@ -22,7 +22,7 @@ func phusFields(e *log.Entry) *log.Entry {
 		Time("now", ctxTime).
 		Strs("months", ctxMonths).
 		Ints("primes", ctxFirst10Primes).
-		Any("users", ctxUsers).
+		Objects("users", ctxUsers).
 		Err(ctxErr)
 
 	return e


### PR DESCRIPTION
I implement `Objects` method by reflection in https://github.com/phuslu/log/blob/v1.0.98/logger.go#L2032-L2066 to improve performance in the case.
Although it cannot beat the Specialization of zerolog/zap, but worth to reduce the nanoseconds of execution.