### PR TITLE
add slog with phuslog backend benchmark

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/apex/log v1.9.0
 	github.com/inconshreveable/log15 v2.16.0+incompatible
-	github.com/phuslu/log v1.0.99
+	github.com/phuslu/log v1.0.100
 	github.com/rs/zerolog v1.30.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/zerodha/logf v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/phuslu/log v1.0.99 h1:DcsYN7ONwGjJ+kjx0QacDq4p90xYFhcY6kRaMvjo9Fg=
-github.com/phuslu/log v1.0.99/go.mod h1:F8osGJADo5qLK/0F88djWwdyoZZ9xDJQL1HYRHFEkS0=
+github.com/phuslu/log v1.0.100 h1:seslWZ/4OqrMjLUk9e0O6aX6Xew2jX8BngePyRy89ak=
+github.com/phuslu/log v1.0.100/go.mod h1:F8osGJADo5qLK/0F88djWwdyoZZ9xDJQL1HYRHFEkS0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/setup_test.go
+++ b/setup_test.go
@@ -101,6 +101,7 @@ var loggers = []logBenchmark{
 	&zapBench{},
 	&zapSugarBench{},
 	&slogBench{},
+	&slogPhuslogBench{},
 	&slogZapBench{},
 	&apexBench{},
 	&logrusBench{},

--- a/slog_phuslog_test.go
+++ b/slog_phuslog_test.go
@@ -1,0 +1,37 @@
+package bench
+
+import (
+	"io"
+	"log/slog"
+
+	phuslog "github.com/phuslu/log"
+)
+
+type slogPhuslogBench struct {
+	slogBench
+}
+
+// slog frontend with phuslog backend.
+func newSlogPhuslog(w io.Writer) *slog.Logger {
+	return slog.New(phuslog.SlogNewJSONHandler(w, nil))
+}
+
+func newSlogPhuslogWithCtx(w io.Writer, attr []slog.Attr) *slog.Logger {
+	return slog.New(phuslog.SlogNewJSONHandler(w, nil).WithAttrs(attr))
+}
+
+func (b *slogPhuslogBench) new(w io.Writer) logBenchmark {
+	return &slogBench{
+		l: newSlogPhuslog(w),
+	}
+}
+
+func (b *slogPhuslogBench) newWithCtx(w io.Writer) logBenchmark {
+	return &slogBench{
+		l: newSlogPhuslogWithCtx(w, slogAttrs()),
+	}
+}
+
+func (b *slogPhuslogBench) name() string {
+	return "SlogPhuslog"
+}


### PR DESCRIPTION
I implemented the fastest slog.JSONHandler in phuslog, so I'd like to add it to this more common benchmark.
In my rough tests, its performance is between zerolog and zap -- Significantly faster than slog and slogzap.